### PR TITLE
Add CLI runner for novel workflow

### DIFF
--- a/agents_demo/pyproject.toml
+++ b/agents_demo/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
 [project.optional-dependencies]
 dev = ["mypy>=1.11.1", "ruff>=0.6.1"]
 
+[project.scripts]
+run-writer = "agent.run_writer:main"
+
 [build-system]
 requires = ["setuptools>=73.0.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/agents_demo/src/agent/run_writer.py
+++ b/agents_demo/src/agent/run_writer.py
@@ -1,0 +1,29 @@
+import argparse
+from agent.writer import novel_workflow
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the novel writer workflow")
+    parser.add_argument("title", help="Title of the novel")
+    parser.add_argument("idea", help="Basic idea of the story")
+    parser.add_argument("chapter_count", type=int, help="Number of chapters to generate")
+    args = parser.parse_args()
+
+    initial_state = {
+        "user_input": {
+            "title": args.title,
+            "idea": args.idea,
+            "chapter_cnt": args.chapter_count,
+        },
+        "outline": None,
+        "outline_feedback": None,
+        "chapter_index": 0,
+        "chapter_text": None,
+        "human_feedback": None,
+    }
+
+    novel_workflow.invoke(initial_state)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run_writer.py` to run the novel workflow from command line
- expose a `run-writer` console script in pyproject

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for langgraph, langchain_core)*

------
https://chatgpt.com/codex/tasks/task_e_688c674ced848330ac2d0e3fdee60b99